### PR TITLE
db: rename IntermittentDB and intermittents.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.venv/
 /*.egg-info/
+/data/
 config.json
-intermittents.json
 *.pyc
 cgi-bin

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -1,38 +1,43 @@
 import json
 
-class IntermittentsDB:
+class IssuesDB:
     def __init__(self, db):
-        self.intermittents = db
+        self.data = db
 
 
     def query(self, name):
         # In Python 3 filter() is lazy, so we build an array right here so that it can be jsonified
-        return [x for x in filter(lambda i: name in i['title'], self.intermittents)]
+        return [x for x in filter(lambda i: name in i['title'], self.data)]
 
 
     def add(self, name, number):
-        for i in self.intermittents:
+        for i in self.data:
             if i['number'] == number:
                 return
-        self.intermittents.extend([{'title': name, 'number': number}])
+        self.data.extend([{'title': name, 'number': number}])
 
     
     def remove(self, number):
-        for idx, i in enumerate(self.intermittents):
+        for idx, i in enumerate(self.data):
             if i['number'] == number:
-                self.intermittents.pop(idx)
+                self.data.pop(idx)
                 return
 
 
-class AutoWriteDB(IntermittentsDB):
+class AutoWriteDB:
     def __init__(self, filename):
         self.filename = filename
         with open(filename) as f:
-            IntermittentsDB.__init__(self, json.loads(f.read()))
+            super().__init__(json.loads(f.read()))
 
     def __enter__(self):
         return self
 
     def __exit__(self, etype, evalue, etrace):
         with open(self.filename, 'w') as f:
-            f.write(json.dumps(self.intermittents))
+            f.write(json.dumps(self.data))
+
+
+class AutoWriteIssuesDB(AutoWriteDB, IssuesDB):
+    def __init__(self, filename):
+        super().__init__(filename)

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -24,7 +24,7 @@ class IssuesDB:
                 return
 
 
-class AutoWriteDB:
+class AutoWriteIssuesDB(IssuesDB):
     def __init__(self, filename):
         self.filename = filename
         with open(filename) as f:
@@ -36,8 +36,3 @@ class AutoWriteDB:
     def __exit__(self, etype, evalue, etrace):
         with open(self.filename, 'w') as f:
             f.write(json.dumps(self.data))
-
-
-class AutoWriteIssuesDB(AutoWriteDB, IssuesDB):
-    def __init__(self, filename):
-        super().__init__(filename)

--- a/intermittent_tracker/query.py
+++ b/intermittent_tracker/query.py
@@ -10,11 +10,11 @@ except:
     import json
 
 from . import handlers
-from .db import IntermittentsDB
+from .db import IssuesDB
 
 def query(name):
-    with open('intermittents.json') as f:
-        db = IntermittentsDB(json.loads(f.read()))
+    with open('data/issues.json') as f:
+        db = IssuesDB(json.loads(f.read()))
     return db.query(name)
 
 if __name__ == "__main__":

--- a/intermittent_tracker/tests.py
+++ b/intermittent_tracker/tests.py
@@ -1,4 +1,4 @@
-from db import IntermittentsDB
+from db import IssuesDB
 import handlers
 import json
 
@@ -9,7 +9,7 @@ def query(db, name):
     return None
 
 with open('tests.json') as f:
-    db = IntermittentsDB(json.loads(f.read()))
+    db = IssuesDB(json.loads(f.read()))
 
 assert query(db, 'many-draw-calls.html') == 14391
 assert query(db, '2d.fillStyle.parse.css-color-4-rgba-4.html') == 14389

--- a/intermittent_tracker/webhook.py
+++ b/intermittent_tracker/webhook.py
@@ -10,7 +10,7 @@ except:
     import json
 
 from . import handlers
-from .db import AutoWriteDB
+from .db import AutoWriteIssuesDB
 
 def handler(payload_raw):
     payload = json.loads(payload_raw)
@@ -18,7 +18,7 @@ def handler(payload_raw):
     if action not in ['labeled', 'unlabeled', 'edited', 'closed', 'reopened']:
         return
 
-    with AutoWriteDB('intermittents.json') as db:
+    with AutoWriteIssuesDB('data/issues.json') as db:
         issue = payload['issue']
         if action == 'labeled':
             handlers.on_label_added(db, payload['label']['name'],


### PR DESCRIPTION
~~**Experimental: feedback welcome, but please don’t merge or deploy yet!**~~

IntermittentDB and intermittents.json are currently how we store our list of I-intermittent issues. This patch paves the way to storing other intermittents-related data, by renaming:

* IntermittentDB → IssuesDB
* intermittents.json → data/issues.json

Note that the only functional change is that intermittents.json is now data/issues.json.

## Testing

To avoid `python -i` errors, edit intermittent_tracker/webhook.py to remove the if `__main__` block.

```sh
$ printf '[]' > data/issues.json
$ python3 -im intermittent_tracker.webhook
```
```python
>>> handler('{"action":"labeled","issue":{"title":"x","number":1,"state":"open"},"label":{"name":"I-intermittent"}}')
```

The contents of data/issues.json should be as follows:

```
[{"title": "x", "number": 1}]
```

## Migrating

To prepare the production instance:

```sh
$ mkdir -p data
$ ln intermittents.json data/issues.json
```