### PR TITLE
dashboard backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.venv/
 /*.egg-info/
+/data/
 config.json
-intermittents.json
 *.pyc
 cgi-bin

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ To run tests:
 $ . .venv/bin/activate
 $ python3 -m intermittent_tracker.tests
 ```
+
+To generate a `dashboard_secret` for config.json:
+
+```sh
+$ python3 -c 'import secrets; print(secrets.token_urlsafe())'
+```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,5 @@ To run tests:
 
 ```sh
 $ . .venv/bin/activate
-$ cd intermittent_tracker
-$ python3 tests.py
+$ python3 -m intermittent_tracker.tests
 ```

--- a/config.json.example
+++ b/config.json.example
@@ -1,1 +1,1 @@
-{"token": "abcdefghijklmnop", "port": 5000}
+{"github_token": "abcdefghijklmnop", "dashboard_secret": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq", "port": 5000}

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -23,4 +23,6 @@ def test(request):
 def post_attempts(request):
     db = DashboardDB()
     db.insert_attempts(*request.json)
-    return ('', 204)
+    issues = IssuesDB.readonly()
+    result = [attempt for attempt in request.json if not issues.query(attempt['path'])]
+    return json.dumps(result)

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -48,6 +48,16 @@ def get_attempts(request):
 def post_attempts(request):
     db = DashboardDB()
     db.insert_attempts(*request.json)
-    issues = IssuesDB.readonly()
-    result = [attempt for attempt in request.json if not issues.query(attempt['path'])]
+    return query(request)
+
+def query(request):
+    issues_db = IssuesDB.readonly()
+    result = {'known': [], 'unknown': []}
+    for attempt in request.json:
+        test = {'path': attempt['path'], 'subtest': attempt.get('subtest')}
+        issues = issues_db.query(attempt['path'])
+        if issues:
+            result['known'].append(test | {'issues': issues})
+        else:
+            result['unknown'].append(test)
     return json.dumps(result)

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -9,9 +9,9 @@ def tests(request):
     db = DashboardDB()
     result = []
     if 'group' in request.args:
-        query = 'SELECT *, rowid, max("unexpected_count"), max("last_unexpected") FROM "test" WHERE "last_unexpected" IS NOT NULL GROUP BY "path" ORDER BY max("last_unexpected") DESC'
+        query = 'SELECT rowid, *, max("unexpected_count"), max("last_unexpected") FROM "test" WHERE "last_unexpected" IS NOT NULL GROUP BY "path" ORDER BY max("last_unexpected") DESC'
     else:
-        query = 'SELECT *, rowid FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC'
+        query = 'SELECT rowid, * FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC'
     for test in db.con.execute(query).fetchall():
         result.append(dict(test) | issues_mixin(test['path']))
     return json.dumps(result)
@@ -41,7 +41,7 @@ def get_attempts(request):
         # were inserted later in the same second than previous requests
         where += ' AND "time" >= ?'
         params.append(int(request.args['since']))
-    for attempt in db.con.execute(f'SELECT *, rowid FROM "attempt" WHERE "actual" != "expected" {where} ORDER BY "time" DESC', params).fetchall():
+    for attempt in db.con.execute(f'SELECT rowid, * FROM "attempt" WHERE "actual" != "expected" {where} ORDER BY "time" DESC', params).fetchall():
         result.append(dict(attempt))
     return json.dumps(result)
 

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -5,23 +5,19 @@ def issues_mixin(path):
     issues = IssuesDB.readonly()
     return {'issues': issues.query(path)}
 
-def decode_subtest(result):
-    result['subtest'] = DashboardDB.decode_subtest(result['subtest'])
-    return result
-
 def tests(request):
     db = DashboardDB()
     result = []
     for test in db.con.execute('SELECT *, rowid FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC').fetchall():
-        result.append(decode_subtest(dict(test)) | issues_mixin(test['path']))
+        result.append(dict(test) | issues_mixin(test['path']))
     return json.dumps(result)
 
 def test(request):
     db = DashboardDB()
     result = {'unexpected': []} | issues_mixin(request.args['path'])
-    where = (request.args['path'], DashboardDB.encode_subtest(request.args['subtest']))
+    where = (request.args['path'], request.args['subtest'])
     for attempt in db.con.execute('SELECT *, rowid FROM "attempt" WHERE "path" = ? AND "subtest" = ? AND "actual" != "expected" ORDER BY "time" DESC', where).fetchall():
-        result['unexpected'].append(decode_subtest(dict(attempt)))
+        result['unexpected'].append(dict(attempt))
     return json.dumps(result)
 
 def post_attempts(request):

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -1,0 +1,26 @@
+from .db import DashboardDB, IssuesDB
+import json
+
+def issues_mixin(path):
+    issues = IssuesDB.readonly()
+    return {'issues': issues.query(path)}
+
+def tests(request):
+    db = DashboardDB.connect()
+    result = []
+    for test in db.con.execute('SELECT * FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC').fetchall():
+        result.append(dict(test) | issues_mixin(test['path']))
+    return json.dumps(result)
+
+def test(request):
+    db = DashboardDB.connect()
+    result = {'unexpected': []} | issues_mixin(request.args['path'])
+    where = (request.args['path'], request.args['subtest'])
+    for attempt in db.con.execute('SELECT * FROM "attempt" WHERE "path" = ? AND "subtest" = ? AND "actual" != "expected" ORDER BY "time" DESC', where).fetchall():
+        result['unexpected'].append(dict(attempt))
+    return json.dumps(result)
+
+def post_attempts(request):
+    db = DashboardDB.connect()
+    db.insert_attempts(*request.json)
+    return ('', 204)

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -6,14 +6,14 @@ def issues_mixin(path):
     return {'issues': issues.query(path)}
 
 def tests(request):
-    db = DashboardDB.connect()
+    db = DashboardDB()
     result = []
     for test in db.con.execute('SELECT * FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC').fetchall():
         result.append(dict(test) | issues_mixin(test['path']))
     return json.dumps(result)
 
 def test(request):
-    db = DashboardDB.connect()
+    db = DashboardDB()
     result = {'unexpected': []} | issues_mixin(request.args['path'])
     where = (request.args['path'], request.args['subtest'])
     for attempt in db.con.execute('SELECT * FROM "attempt" WHERE "path" = ? AND "subtest" = ? AND "actual" != "expected" ORDER BY "time" DESC', where).fetchall():
@@ -21,6 +21,6 @@ def test(request):
     return json.dumps(result)
 
 def post_attempts(request):
-    db = DashboardDB.connect()
+    db = DashboardDB()
     db.insert_attempts(*request.json)
     return ('', 204)

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -8,16 +8,41 @@ def issues_mixin(path):
 def tests(request):
     db = DashboardDB()
     result = []
-    for test in db.con.execute('SELECT *, rowid FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC').fetchall():
+    if 'group' in request.args:
+        query = 'SELECT *, rowid, max("unexpected_count"), max("last_unexpected") FROM "test" WHERE "last_unexpected" IS NOT NULL GROUP BY "path" ORDER BY max("last_unexpected") DESC'
+    else:
+        query = 'SELECT *, rowid FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC'
+    for test in db.con.execute(query).fetchall():
         result.append(dict(test) | issues_mixin(test['path']))
     return json.dumps(result)
 
-def test(request):
+def get_attempts(request):
     db = DashboardDB()
-    result = {'unexpected': []} | issues_mixin(request.args['path'])
-    where = (request.args['path'], request.args['subtest'])
-    for attempt in db.con.execute('SELECT *, rowid FROM "attempt" WHERE "path" = ? AND "subtest" = ? AND "actual" != "expected" ORDER BY "time" DESC', where).fetchall():
-        result['unexpected'].append(dict(attempt))
+    result = []
+    where = ''
+    params = []
+    if 'path' in request.args:
+        where += ' AND "path" = ?'
+        params.append(request.args['path'])
+    if 'subtest' in request.args:
+        where += ' AND "subtest" = ?'
+        params.append(request.args['subtest'])
+    if 'branch' in request.args:
+        where += ' AND "branch" = ?'
+        params.append(request.args['branch'])
+    if 'build_url' in request.args:
+        where += ' AND "build_url" = ?'
+        params.append(request.args['build_url'])
+    if 'pull_url' in request.args:
+        where += ' AND "pull_url" = ?'
+        params.append(request.args['pull_url'])
+    if 'since' in request.args:
+        # use >= rather than > to allow repeated requests to pick up rows that
+        # were inserted later in the same second than previous requests
+        where += ' AND "time" >= ?'
+        params.append(int(request.args['since']))
+    for attempt in db.con.execute(f'SELECT *, rowid FROM "attempt" WHERE "actual" != "expected" {where} ORDER BY "time" DESC', params).fetchall():
+        result.append(dict(attempt))
     return json.dumps(result)
 
 def post_attempts(request):

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -59,14 +59,6 @@ class DashboardDB:
             break
 
     @staticmethod
-    def encode_subtest(subtest):
-        return '' if subtest is None else f'={subtest}'
-
-    @staticmethod
-    def decode_subtest(subtest):
-        return subtest[1:] if len(subtest) > 0 else None
-
-    @staticmethod
     def migrate(filename='data/dashboard.sqlite'):
         con = connect(filename)
         version = 0
@@ -98,7 +90,6 @@ class DashboardDB:
 
     def insert_attempt(self, *, path, subtest=None, expected, actual, time=None,
                        message=None, stack=None, branch=None, build_url=None, pull_url=None):
-        subtest = DashboardDB.encode_subtest(subtest)
         if time is None:
             time = now()
         self.con.execute('SAVEPOINT "insert_attempt"')

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -3,14 +3,21 @@ import sqlite3
 import time
 
 class IssuesDB:
+    @staticmethod
+    def readonly(filename='data/issues.json'):
+        with open(filename) as f:
+            return IssuesDB(json.loads(f.read()))
+
+    @staticmethod
+    def autowrite(filename='data/issues.json'):
+        return AutoWriteIssuesDB(filename)
+
     def __init__(self, db):
         self.data = db
-
 
     def query(self, name):
         # In Python 3 filter() is lazy, so we build an array right here so that it can be jsonified
         return [x for x in filter(lambda i: name in i['title'], self.data)]
-
 
     def add(self, name, number):
         for i in self.data:
@@ -18,7 +25,6 @@ class IssuesDB:
                 return
         self.data.extend([{'title': name, 'number': number}])
 
-    
     def remove(self, number):
         for idx, i in enumerate(self.data):
             if i['number'] == number:
@@ -46,6 +52,10 @@ class AutoWriteIssuesDB(AutoWriteDB, IssuesDB):
 
 
 class DashboardDB:
+    @staticmethod
+    def connect():
+        return DashboardDB('data/dashboard.sqlite')
+
     def __init__(self, filename):
         self.version = 0  # schema version (0 = empty database)
         self.con = sqlite3.connect(filename)

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -142,12 +142,16 @@ class DashboardDB:
                        message=None, stack=None, branch=None, build_url=None, pull_url=None):
         if time is None:
             time = now()
+        self.con.execute('SAVEPOINT "insert_attempt"')
         self.con.execute('INSERT INTO "attempt" VALUES (?,?,?,?,?,?,?,?,?,?)',
             (path, subtest, expected, actual, time, message, stack, branch, build_url, pull_url))
+        self.con.execute('RELEASE "insert_attempt"')
 
     def insert_attempts(self, *attempts):
+        self.con.execute('SAVEPOINT "insert_attempts"')
         for attempt in attempts:
             self.insert_attempt(**attempt)
+        self.con.execute('RELEASE "insert_attempts"')
 
 
 def now():

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -1,38 +1,43 @@
 import json
 
-class IntermittentsDB:
+class IssuesDB:
     def __init__(self, db):
-        self.intermittents = db
+        self.data = db
 
 
     def query(self, name):
         # In Python 3 filter() is lazy, so we build an array right here so that it can be jsonified
-        return [x for x in filter(lambda i: name in i['title'], self.intermittents)]
+        return [x for x in filter(lambda i: name in i['title'], self.data)]
 
 
     def add(self, name, number):
-        for i in self.intermittents:
+        for i in self.data:
             if i['number'] == number:
                 return
-        self.intermittents.extend([{'title': name, 'number': number}])
+        self.data.extend([{'title': name, 'number': number}])
 
     
     def remove(self, number):
-        for idx, i in enumerate(self.intermittents):
+        for idx, i in enumerate(self.data):
             if i['number'] == number:
-                self.intermittents.pop(idx)
+                self.data.pop(idx)
                 return
 
 
-class AutoWriteDB(IntermittentsDB):
+class AutoWriteDB:
     def __init__(self, filename):
         self.filename = filename
         with open(filename) as f:
-            IntermittentsDB.__init__(self, json.loads(f.read()))
+            super().__init__(json.loads(f.read()))
 
     def __enter__(self):
         return self
 
     def __exit__(self, etype, evalue, etrace):
         with open(self.filename, 'w') as f:
-            f.write(json.dumps(self.intermittents))
+            f.write(json.dumps(self.data))
+
+
+class AutoWriteIssuesDB(AutoWriteDB, IssuesDB):
+    def __init__(self, filename):
+        super().__init__(filename)

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -24,7 +24,7 @@ class IssuesDB:
                 return
 
 
-class AutoWriteDB:
+class AutoWriteIssuesDB(IssuesDB):
     def __init__(self, filename):
         self.filename = filename
         with open(filename) as f:
@@ -36,8 +36,3 @@ class AutoWriteDB:
     def __exit__(self, etype, evalue, etrace):
         with open(self.filename, 'w') as f:
             f.write(json.dumps(self.data))
-
-
-class AutoWriteIssuesDB(AutoWriteDB, IssuesDB):
-    def __init__(self, filename):
-        super().__init__(filename)

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 import time
+from itertools import count
 
 class IssuesDB:
     @staticmethod
@@ -73,64 +74,13 @@ class DashboardDB:
                 raise
 
         # schema migrations
-        if self.version < 1:
-            self.con.execute("BEGIN")
-            self.con.execute("""
-                CREATE TABLE "meta" (
-                "version" INTEGER NOT NULL
-                )
-            """)
-            self.con.execute("""
-                INSERT INTO "meta" VALUES (1)
-            """)
-            self.con.execute("""
-                CREATE TABLE "test" (
-                "path" TEXT NOT NULL                        -- test name
-                , "subtest" TEXT
-                , "unexpected_count" INTEGER NOT NULL
-                , "last_unexpected" INTEGER                 -- unix time
-                , PRIMARY KEY ("path", "subtest")
-                )
-            """)
-            self.con.execute("""
-                CREATE TABLE "attempt" (
-                "path" TEXT NOT NULL                        -- test name
-                , "subtest" TEXT
-                , "expected" TEXT NOT NULL                  -- status e.g. PASS
-                , "actual" TEXT NOT NULL                    -- status e.g. FAIL
-                , "time" INTEGER NOT NULL                   -- unix time
-                , "message" TEXT DEFAULT NULL               -- test output
-                , "stack" TEXT DEFAULT NULL
-                , "branch" TEXT DEFAULT NULL                -- e.g. auto, try
-                , "build_url" TEXT DEFAULT NULL             -- e.g. https://github.com/servo/servo/actions/runs/4030556190/jobs/6929482570
-                , "pull_url" TEXT DEFAULT NULL              -- e.g. https://github.com/servo/servo/pull/29306
-                , FOREIGN KEY ("path", "subtest") REFERENCES "test"
-                )
-            """)
-            self.con.execute("""
-                CREATE INDEX "attempt.test" ON "attempt" ("path", "subtest")
-            """)
-            self.con.execute("""
-                CREATE INDEX "attempt.build" ON "attempt" ("build_url")
-            """)
-            self.con.execute("""
-                CREATE INDEX "attempt.pull" ON "attempt" ("pull_url")
-            """)
-            self.con.execute("""
-                CREATE TRIGGER "test.count_unexpected"
-                INSERT ON "attempt"
-                BEGIN
-                    INSERT INTO "test" VALUES (
-                        new."path", new."subtest"
-                        , CASE WHEN new."actual" != new."expected" THEN 1 ELSE 0 END
-                        , CASE WHEN new."actual" != new."expected" THEN new."time" ELSE NULL END
-                    ) ON CONFLICT DO UPDATE SET
-                        "unexpected_count" = "unexpected_count" + 1
-                        , "last_unexpected" = new."time"
-                        WHERE new."actual" != new."expected";
-                END
-            """)
-            self.con.execute("COMMIT")
+        for version in count(self.version + 1):
+            try:
+                with open(f'schema/dashboard.{version}.sql') as f:
+                    self.con.executescript(f'BEGIN; {f.read()}; COMMIT')
+                    self.version = version
+            except FileNotFoundError:
+                break
 
     def __enter__(self):
         self.con.__enter__()

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -59,6 +59,14 @@ class DashboardDB:
             break
 
     @staticmethod
+    def encode_subtest(subtest):
+        return '' if subtest is None else f'={subtest}'
+
+    @staticmethod
+    def decode_subtest(subtest):
+        return subtest[1:] if len(subtest) > 0 else None
+
+    @staticmethod
     def migrate(filename='data/dashboard.sqlite'):
         con = connect(filename)
         version = 0
@@ -90,6 +98,7 @@ class DashboardDB:
 
     def insert_attempt(self, *, path, subtest=None, expected, actual, time=None,
                        message=None, stack=None, branch=None, build_url=None, pull_url=None):
+        subtest = DashboardDB.encode_subtest(subtest)
         if time is None:
             time = now()
         self.con.execute('SAVEPOINT "insert_attempt"')

--- a/intermittent_tracker/flask_server.py
+++ b/intermittent_tracker/flask_server.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify
-from . import query, webhook
+from . import query, webhook, dashboard
 import json
+
 app = Flask(__name__)
 
 @app.route("/query.py")
@@ -13,6 +14,19 @@ def querypy():
 def webhookpy():
     webhook.handler(request.form.get('payload', '{}'))
     return ('', 204)
+
+@app.route('/dashboard/tests')
+def dashboard_tests():
+    return dashboard.tests(request)
+
+@app.route('/dashboard/test')
+def dashboard_test():
+    return dashboard.test(request)
+
+# TODO authenticate requests for this endpoint
+@app.route('/dashboard/attempts', methods=['POST'])
+def dashboard_post_attempts():
+    return dashboard.post_attempts(request)
 
 @app.route('/')
 def index():

--- a/intermittent_tracker/flask_server.py
+++ b/intermittent_tracker/flask_server.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from . import query, webhook, dashboard
+from .db import DashboardDB
 import json
 
 app = Flask(__name__)
@@ -36,6 +37,7 @@ def main():
     with open('config.json') as f:
         config = json.loads(f.read())
         assert('port' in config)
+    DashboardDB.migrate()
     app.run(port=config['port'])
 
 if __name__ == "__main__":

--- a/intermittent_tracker/flask_server.py
+++ b/intermittent_tracker/flask_server.py
@@ -44,6 +44,10 @@ def dashboard_post_attempts():
     else:
         return dashboard.get_attempts(request)
 
+@app.route('/dashboard/query', methods=['POST'])
+def dashboard_query():
+    return dashboard.query(request)
+
 @app.route('/')
 def index():
     return "Hi!"

--- a/intermittent_tracker/query.py
+++ b/intermittent_tracker/query.py
@@ -10,11 +10,11 @@ except:
     import json
 
 from . import handlers
-from .db import IntermittentsDB
+from .db import IssuesDB
 
 def query(name):
-    with open('intermittents.json') as f:
-        db = IntermittentsDB(json.loads(f.read()))
+    with open('data/issues.json') as f:
+        db = IssuesDB(json.loads(f.read()))
     return db.query(name)
 
 if __name__ == "__main__":

--- a/intermittent_tracker/query.py
+++ b/intermittent_tracker/query.py
@@ -13,9 +13,7 @@ from . import handlers
 from .db import IssuesDB
 
 def query(name):
-    with open('data/issues.json') as f:
-        db = IssuesDB(json.loads(f.read()))
-    return db.query(name)
+    return IssuesDB.readonly().query(name)
 
 if __name__ == "__main__":
     print("Content-Type: application/json;charset=utf-8")

--- a/intermittent_tracker/sync.py
+++ b/intermittent_tracker/sync.py
@@ -4,7 +4,7 @@ import json
 with open('config.json') as f:
     config = json.loads(f.read())
 
-gh = login(token=config['token'])
+gh = login(token=config['github_token'])
 
 issues = gh.issues_on(username='servo',
                       repository='servo',

--- a/intermittent_tracker/tests.py
+++ b/intermittent_tracker/tests.py
@@ -1,4 +1,4 @@
-from db import IssuesDB
+from db import IssuesDB, DashboardDB
 import handlers
 import json
 
@@ -62,5 +62,21 @@ handlers.on_label_added(db, 'C-disabled', 'baz.html', 12345, 'closed')
 
 handlers.on_issue_reopened(db, 'baz.html', 12345, ['I-intermittent', 'C-disabled'])
 assert query(db, 'bar.html') == None
+
+
+dashboard = DashboardDB(":memory:")
+dashboard.insert_attempts(
+    {'path':'a','subtest':'b','expected':'FAIL','actual':'PASS','time':1},
+    {'path':'a','subtest':'c','expected':'PASS','actual':'PASS','time':2})
+tests = dashboard.con.execute('SELECT * FROM "test"').fetchall()
+assert [tuple(x) for x in tests] == [('a','b',1,1), ('a','c',0,None)]
+attempts = dashboard.con.execute('SELECT * FROM "attempt"')
+assert tuple(attempts.fetchone()) == ('a','b','FAIL','PASS',1,None,None,None,None,None)
+assert tuple(attempts.fetchone()) == ('a','c','PASS','PASS',2,None,None,None,None,None)
+
+dashboard.insert_attempt(path='a', subtest='c', expected='PASS', actual='FAIL', time=3)
+tests = dashboard.con.execute('SELECT * FROM "test"').fetchall()
+assert [tuple(x) for x in tests] == [('a','b',1,1), ('a','c',1,3)]
+
 
 print('All tests passed.')

--- a/intermittent_tracker/tests.py
+++ b/intermittent_tracker/tests.py
@@ -1,4 +1,4 @@
-from db import IntermittentsDB
+from db import IssuesDB
 import handlers
 import json
 
@@ -9,7 +9,7 @@ def query(db, name):
     return None
 
 with open('tests.json') as f:
-    db = IntermittentsDB(json.loads(f.read()))
+    db = IssuesDB(json.loads(f.read()))
 
 assert query(db, 'many-draw-calls.html') == 14391
 assert query(db, '2d.fillStyle.parse.css-color-4-rgba-4.html') == 14389

--- a/intermittent_tracker/tests.py
+++ b/intermittent_tracker/tests.py
@@ -8,9 +8,7 @@ def query(db, name):
         return result[0]['number']
     return None
 
-with open('tests.json') as f:
-    db = IssuesDB(json.loads(f.read()))
-
+db = IssuesDB.readonly('tests.json')
 assert query(db, 'many-draw-calls.html') == 14391
 assert query(db, '2d.fillStyle.parse.css-color-4-rgba-4.html') == 14389
 assert query(db, 'mozbrowserlocationchange_event.html') == None

--- a/intermittent_tracker/tests.py
+++ b/intermittent_tracker/tests.py
@@ -1,5 +1,5 @@
-from db import IssuesDB, DashboardDB
-import handlers
+from .db import IssuesDB, DashboardDB
+from . import handlers
 import json
 
 def query(db, name):
@@ -8,7 +8,7 @@ def query(db, name):
         return result[0]['number']
     return None
 
-db = IssuesDB.readonly('tests.json')
+db = IssuesDB.readonly('intermittent_tracker/tests.json')
 assert query(db, 'many-draw-calls.html') == 14391
 assert query(db, '2d.fillStyle.parse.css-color-4-rgba-4.html') == 14389
 assert query(db, 'mozbrowserlocationchange_event.html') == None

--- a/intermittent_tracker/webhook.py
+++ b/intermittent_tracker/webhook.py
@@ -10,7 +10,7 @@ except:
     import json
 
 from . import handlers
-from .db import AutoWriteIssuesDB
+from .db import IssuesDB
 
 def handler(payload_raw):
     payload = json.loads(payload_raw)
@@ -18,7 +18,7 @@ def handler(payload_raw):
     if action not in ['labeled', 'unlabeled', 'edited', 'closed', 'reopened']:
         return
 
-    with AutoWriteIssuesDB('data/issues.json') as db:
+    with IssuesDB.autowrite() as db:
         issue = payload['issue']
         if action == 'labeled':
             handlers.on_label_added(db, payload['label']['name'],

--- a/intermittent_tracker/webhook.py
+++ b/intermittent_tracker/webhook.py
@@ -10,7 +10,7 @@ except:
     import json
 
 from . import handlers
-from .db import AutoWriteDB
+from .db import AutoWriteIssuesDB
 
 def handler(payload_raw):
     payload = json.loads(payload_raw)
@@ -18,7 +18,7 @@ def handler(payload_raw):
     if action not in ['labeled', 'unlabeled', 'edited', 'closed', 'reopened']:
         return
 
-    with AutoWriteDB('intermittents.json') as db:
+    with AutoWriteIssuesDB('data/issues.json') as db:
         issue = payload['issue']
         if action == 'labeled':
             handlers.on_label_added(db, payload['label']['name'],

--- a/schema/dashboard.1.sql
+++ b/schema/dashboard.1.sql
@@ -32,6 +32,7 @@ CREATE TABLE "attempt" (
 );
 
 CREATE INDEX "attempt.test" ON "attempt" ("path", "subtest");
+CREATE INDEX "attempt.branch" ON "attempt" ("branch");
 CREATE INDEX "attempt.build" ON "attempt" ("build_url");
 CREATE INDEX "attempt.pull" ON "attempt" ("pull_url");
 

--- a/schema/dashboard.1.sql
+++ b/schema/dashboard.1.sql
@@ -5,9 +5,31 @@ CREATE TABLE "meta" (
 -- dashboard.2.sql should UPDATE "meta" SET "version" = 2; and so on
 INSERT INTO "meta" VALUES (1);
 
+-- tests are identified by (path,subtest), but some tests are not subtests.
+-- the obvious representation for such tests would be (path,NULL), but sqlite
+-- makes the (legal) decision to allow (path,NULL) to effectively bypass
+--
+-- 1.  PRIMARY KEY constraints (“Each row in a table with a primary key must have a unique
+--     combination of values in its primary key columns. For the purposes of determining the
+--     uniqueness of primary key values, NULL values are considered distinct from all other
+--     values, including other NULLs.”)
+--
+-- 2.  UNIQUE constraints (“For each UNIQUE constraint on the table, each row must contain a unique
+--     combination of values in the columns identified by the UNIQUE constraint. For the purposes of
+--     UNIQUE constraints, NULL values are considered distinct from all other values, including
+--     other NULLs.”)
+--
+-- 3.  FOREIGN KEY constraints (“The foreign key constraint is satisfied if for each row in the
+--     child table either one or more of the child key columns are NULL, or there exists a row in
+--     the parent table for which each parent key column contains a value equal to the value in its
+--     associated child key column.”)
+--
+-- we want (path,NULL) to be treated like an ordinary value, but we can’t have
+-- that, so let’s represent tests here as (path,'') and (path,'='+subtest).
+
 CREATE TABLE "test" (
     "path" TEXT NOT NULL                        -- test name
-    , "subtest" TEXT
+    , "subtest" TEXT NOT NULL                   -- if subtest, '='+subtest, else ''
     , "unexpected_count" INTEGER NOT NULL
     , "last_unexpected" INTEGER                 -- unix time
     , PRIMARY KEY ("path", "subtest")
@@ -15,7 +37,7 @@ CREATE TABLE "test" (
 
 CREATE TABLE "attempt" (
     "path" TEXT NOT NULL                        -- test name
-    , "subtest" TEXT
+    , "subtest" TEXT NOT NULL                   -- if subtest, '='+subtest, else ''
     , "expected" TEXT NOT NULL                  -- status e.g. PASS
     , "actual" TEXT NOT NULL                    -- status e.g. FAIL
     , "time" INTEGER NOT NULL                   -- unix time

--- a/schema/dashboard.1.sql
+++ b/schema/dashboard.1.sql
@@ -1,0 +1,43 @@
+CREATE TABLE "meta" (
+    "version" INTEGER NOT NULL
+);
+
+-- dashboard.2.sql should UPDATE "meta" SET "version" = 2; and so on
+INSERT INTO "meta" VALUES (1);
+
+CREATE TABLE "test" (
+    "path" TEXT NOT NULL                        -- test name
+    , "subtest" TEXT
+    , "unexpected_count" INTEGER NOT NULL
+    , "last_unexpected" INTEGER                 -- unix time
+    , PRIMARY KEY ("path", "subtest")
+);
+
+CREATE TABLE "attempt" (
+    "path" TEXT NOT NULL                        -- test name
+    , "subtest" TEXT
+    , "expected" TEXT NOT NULL                  -- status e.g. PASS
+    , "actual" TEXT NOT NULL                    -- status e.g. FAIL
+    , "time" INTEGER NOT NULL                   -- unix time
+    , "message" TEXT DEFAULT NULL               -- test output
+    , "stack" TEXT DEFAULT NULL
+    , "branch" TEXT DEFAULT NULL                -- e.g. auto, try
+    , "build_url" TEXT DEFAULT NULL             -- e.g. https://github.com/servo/servo/actions/runs/4030556190/jobs/6929482570
+    , "pull_url" TEXT DEFAULT NULL              -- e.g. https://github.com/servo/servo/pull/29306
+    , FOREIGN KEY ("path", "subtest") REFERENCES "test"
+);
+
+CREATE INDEX "attempt.test" ON "attempt" ("path", "subtest");
+CREATE INDEX "attempt.build" ON "attempt" ("build_url");
+CREATE INDEX "attempt.pull" ON "attempt" ("pull_url");
+
+CREATE TRIGGER "test.count_unexpected" INSERT ON "attempt" BEGIN
+    INSERT INTO "test" VALUES (
+        new."path", new."subtest"
+        , CASE WHEN new."actual" != new."expected" THEN 1 ELSE 0 END
+        , CASE WHEN new."actual" != new."expected" THEN new."time" ELSE NULL END
+    ) ON CONFLICT DO UPDATE SET
+        "unexpected_count" = "unexpected_count" + 1
+        , "last_unexpected" = new."time"
+        WHERE new."actual" != new."expected";
+END;

--- a/schema/dashboard.1.sql
+++ b/schema/dashboard.1.sql
@@ -30,14 +30,3 @@ CREATE TABLE "attempt" (
 CREATE INDEX "attempt.test" ON "attempt" ("path", "subtest");
 CREATE INDEX "attempt.build" ON "attempt" ("build_url");
 CREATE INDEX "attempt.pull" ON "attempt" ("pull_url");
-
-CREATE TRIGGER "test.count_unexpected" INSERT ON "attempt" BEGIN
-    INSERT INTO "test" VALUES (
-        new."path", new."subtest"
-        , CASE WHEN new."actual" != new."expected" THEN 1 ELSE 0 END
-        , CASE WHEN new."actual" != new."expected" THEN new."time" ELSE NULL END
-    ) ON CONFLICT DO UPDATE SET
-        "unexpected_count" = "unexpected_count" + 1
-        , "last_unexpected" = new."time"
-        WHERE new."actual" != new."expected";
-END;

--- a/schema/dashboard.1.sql
+++ b/schema/dashboard.1.sql
@@ -5,39 +5,21 @@ CREATE TABLE "meta" (
 -- dashboard.2.sql should UPDATE "meta" SET "version" = 2; and so on
 INSERT INTO "meta" VALUES (1);
 
--- tests are identified by (path,subtest), but some tests are not subtests.
--- the obvious representation for such tests would be (path,NULL), but sqlite
--- makes the (legal) decision to allow (path,NULL) to effectively bypass
---
--- 1.  PRIMARY KEY constraints (“Each row in a table with a primary key must have a unique
---     combination of values in its primary key columns. For the purposes of determining the
---     uniqueness of primary key values, NULL values are considered distinct from all other
---     values, including other NULLs.”)
---
--- 2.  UNIQUE constraints (“For each UNIQUE constraint on the table, each row must contain a unique
---     combination of values in the columns identified by the UNIQUE constraint. For the purposes of
---     UNIQUE constraints, NULL values are considered distinct from all other values, including
---     other NULLs.”)
---
--- 3.  FOREIGN KEY constraints (“The foreign key constraint is satisfied if for each row in the
---     child table either one or more of the child key columns are NULL, or there exists a row in
---     the parent table for which each parent key column contains a value equal to the value in its
---     associated child key column.”)
---
--- we want (path,NULL) to be treated like an ordinary value, but we can’t have
--- that, so let’s represent tests here as (path,'') and (path,'='+subtest).
-
 CREATE TABLE "test" (
     "path" TEXT NOT NULL                        -- test name
-    , "subtest" TEXT NOT NULL                   -- if subtest, '='+subtest, else ''
+    , "_subtest" TEXT NOT NULL AS (IIF(         -- for constraints [1]
+        "subtest" IS NULL, '', '=' || "subtest"))
+    , "subtest" TEXT                            -- actual subtest name
     , "unexpected_count" INTEGER NOT NULL
     , "last_unexpected" INTEGER                 -- unix time
-    , PRIMARY KEY ("path", "subtest")
+    , UNIQUE ("path", "_subtest")
 );
 
 CREATE TABLE "attempt" (
     "path" TEXT NOT NULL                        -- test name
-    , "subtest" TEXT NOT NULL                   -- if subtest, '='+subtest, else ''
+    , "_subtest" TEXT NOT NULL AS (IIF(         -- for constraints [1]
+        "subtest" IS NULL, '', '=' || "subtest"))
+    , "subtest" TEXT                            -- actual subtest name
     , "expected" TEXT NOT NULL                  -- status e.g. PASS
     , "actual" TEXT NOT NULL                    -- status e.g. FAIL
     , "time" INTEGER NOT NULL                   -- unix time
@@ -46,9 +28,18 @@ CREATE TABLE "attempt" (
     , "branch" TEXT DEFAULT NULL                -- e.g. auto, try
     , "build_url" TEXT DEFAULT NULL             -- e.g. https://github.com/servo/servo/actions/runs/4030556190/jobs/6929482570
     , "pull_url" TEXT DEFAULT NULL              -- e.g. https://github.com/servo/servo/pull/29306
-    , FOREIGN KEY ("path", "subtest") REFERENCES "test"
+    , FOREIGN KEY ("path", "_subtest") REFERENCES "test"
 );
 
 CREATE INDEX "attempt.test" ON "attempt" ("path", "subtest");
 CREATE INDEX "attempt.build" ON "attempt" ("build_url");
 CREATE INDEX "attempt.pull" ON "attempt" ("pull_url");
+
+-- [1] tests are identified by (path,subtest), or (path,NULL) if the test is not
+-- a subtest, but sqlite makes the (legal) decision to let (path,NULL) bypass
+-- PRIMARY KEY constraints, UNIQUE constraints, and FOREIGN KEY constraints.
+-- we can work around this by mapping NULL to '' and 'foo' to '='||'foo' in a
+-- generated column, giving us the behaviour we want when used in constraints.
+-- https://sqlite.org/lang_createtable.html#the_primary_key
+-- https://sqlite.org/lang_createtable.html#unique_constraints
+-- https://sqlite.org/foreignkeys.html#fk_basics

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     install_requires=[
         'github3.py',
         'flask',
+        'Flask-HTTPAuth',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This patch adds the backend for an intermittents dashboard including:

* sqlite-based storage for test statistics and attempt results
* GET /dashboard/tests, for listing tests with unexpected results
    * ?group to group subtests by path, max unexpected count, max last unexpected
* GET /dashboard/attempts endpoint, for listing unexpected results for a test
    * ?path= to filter by path
    * ?subtest= to filter by subtest (omit param entirely for NULL)
    * ?branch=&build_url=&pull_url= to filter by any of those
    * ?since= to skip rows older than the given time (for live updates)
* POST /dashboard/query endpoint, for filtering intermittents in a single request
* POST /dashboard/attempts endpoint, for storing new attempt results
    * response format is the same as in POST /dashboard/query

## Testing

```
$ printf \%s '[{"title": "x", "number": 1}]' > data/issues.json

$ curl -fsS 'http://127.0.0.1:5000/dashboard/query' -H 'Content-Type:application/json' \
> -d '[{"path":"x","subtest":"b","expected":"FAIL","actual":"PASS"},{"path":"x","subtest":"c","expected":"PASS","actual":"PASS"}]'

{"known": [{"path": "x", "subtest": "b", "issues": [{"title": "x", "number": 1}]}, {"path": "x", "subtest": "c", "issues": [{"title": "x", "number": 1}]}], "unknown": []}

$ curl -fsS 'http://127.0.0.1:5000/dashboard/attempts' -H 'Content-Type:application/json' \
> -d '[{"path":"x","subtest":"b","expected":"FAIL","actual":"PASS"},{"path":"x","subtest":"c","expected":"PASS","actual":"PASS"}]'

curl: (22) The requested URL returned error: 401

$ curl -fsS 'http://127.0.0.1:5000/dashboard/attempts' -H 'Content-Type:application/json' \
> -H 'Authorization: Bearer ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq' \
> -d '[{"path":"x","subtest":"b","expected":"FAIL","actual":"PASS"},{"path":"x","subtest":"c","expected":"PASS","actual":"PASS"}]'

{"known": [{"path": "x", "subtest": "b", "issues": [{"title": "x", "number": 1}]}, {"path": "x", "subtest": "c", "issues": [{"title": "x", "number": 1}]}], "unknown": []}

$ curl -fsS 'http://127.0.0.1:5000/dashboard/tests' | jq .

[
  {
    "rowid": 1,
    "path": "x",
    "_subtest": "=b",
    "subtest": "b",
    "unexpected_count": 1,
    "last_unexpected": 1675334475,
    "issues": [
      {
        "title": "x",
        "number": 1
      }
    ]
  }
]

$ curl -fsS 'http://127.0.0.1:5000/dashboard/attempts' -H 'Content-Type:application/json' \
> -H 'Authorization: Bearer ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq' \
> -d '[{"path":"x","subtest":"c","expected":"PASS","actual":"FAIL"},{"path":"z","expected":"PASS","actual":"FAIL"}]'

{"known": [{"path": "x", "subtest": "c", "issues": [{"title": "x", "number": 1}]}], "unknown": [{"path": "z", "subtest": null}]}

$ curl -fsS 'http://127.0.0.1:5000/dashboard/tests' | jq .

[
  {
    "rowid": 2,
    "path": "x",
    "_subtest": "=c",
    "subtest": "c",
    "unexpected_count": 1,
    "last_unexpected": 1675334797,
    "issues": [
      {
        "title": "x",
        "number": 1
      }
    ]
  },
  {
    "rowid": 3,
    "path": "z",
    "_subtest": "",
    "subtest": null,
    "unexpected_count": 1,
    "last_unexpected": 1675334797,
    "issues": []
  },
  {
    "rowid": 1,
    "path": "x",
    "_subtest": "=b",
    "subtest": "b",
    "unexpected_count": 1,
    "last_unexpected": 1675334475,
    "issues": [
      {
        "title": "x",
        "number": 1
      }
    ]
  }
]
```

## Migrating

To prepare the production instance, generate a `dashboard_secret` as shown in the README, and rename `token` in config.json to `github_token`.