### PR TITLE
dashboard: fix some attempts-related bugs

### DIFF
--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -1,8 +1,5 @@
 from .db import DashboardDB, IssuesDB
 import json
-import time
-
-FILTER_KEYS = ['path', 'subtest', 'expected', 'actual', 'branch', 'build_url', 'pull_url']
 
 def issues_mixin(path):
     issues = IssuesDB.readonly()
@@ -21,21 +18,10 @@ def tests(request):
 
 def get_attempts(request):
     db = DashboardDB()
-    result = []
-    where = ''
-    params = []
-    for key in FILTER_KEYS:
-        if key in request.args:
-            where += f' AND "{key}" = ?'
-            params.append(request.args[key])
-    if 'since' in request.args:
-        where += ' AND "attempt_id" > ?'
-        params.append(int(request.args['since']))
-    start = time.monotonic_ns()
-    for attempt in db.con.execute(f'SELECT "path", "subtest", "attempt".*, "branch", "build_url", "pull_url" FROM "attempt", "test", "submission" WHERE "test" = "test_id" AND "submission" = "submission_id" AND "actual" != "expected" {where} ORDER BY "attempt_id"', params).fetchall():
-        result.append(dict(attempt))
-    print(f'debug: GET /dashboard/attempts query took {time.monotonic_ns() - start} ns')
-    return json.dumps(result)
+    filters = request.args.to_dict()
+    since = filters.pop('since', None)
+    since = int(since) if since is not None else None
+    return json.dumps(db.select_attempts(since=since, **filters))
 
 def post_attempts(request):
     db = DashboardDB()

--- a/intermittent_tracker/schema/dashboard.2.sql
+++ b/intermittent_tracker/schema/dashboard.2.sql
@@ -32,7 +32,7 @@ CREATE INDEX "submission.pull_url" ON "submission" ("pull_url") WHERE "pull_url"
 
 INSERT INTO "submission" ("time", "branch", "build_url", "pull_url")
 SELECT DISTINCT max("time") AS "time", "branch", "build_url", "pull_url"
-FROM "attempt" GROUP BY "branch", "build_url", "pull_url";
+FROM "attempt" GROUP BY "branch", "build_url", "pull_url" ORDER BY "attempt".rowid;
 
 
 CREATE TABLE "output" (
@@ -48,7 +48,7 @@ CREATE INDEX "output.hash" ON "output" ("message_hash", "stack_hash");
 
 INSERT INTO "output" ("message", "stack")
 SELECT DISTINCT "message", "stack"
-FROM "attempt" GROUP BY "message", "stack";
+FROM "attempt" GROUP BY "message", "stack" ORDER BY "attempt".rowid;
 
 
 -- https://sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes
@@ -65,7 +65,7 @@ CREATE TABLE "_new_test" (
 
 INSERT INTO "_new_test" ("path", "subtest", "unexpected_count", "last_unexpected")
 SELECT "path", "subtest", "unexpected_count", "last_unexpected"
-FROM "test";
+FROM "test" ORDER BY "test".rowid;
 
 DROP TABLE "test";
 ALTER TABLE "_new_test" RENAME TO "test";
@@ -97,7 +97,8 @@ AND "attempt"."message" IS "output"."message"
 AND "attempt"."stack" IS "output"."stack"
 AND "attempt"."branch" IS "submission"."branch"
 AND "attempt"."build_url" IS "submission"."build_url"
-AND "attempt"."pull_url" IS "submission"."pull_url";
+AND "attempt"."pull_url" IS "submission"."pull_url"
+ORDER BY "attempt".rowid;
 
 DROP TABLE "attempt";
 ALTER TABLE "_new_attempt" RENAME TO "attempt";

--- a/intermittent_tracker/static/index.html
+++ b/intermittent_tracker/static/index.html
@@ -169,7 +169,7 @@
                     if (this.filterKeys.includes("path"))
                         this.attempts = this.attemptsRaw;
                     else
-                        this.attempts = mergeAndSort(this.attempts, coalesceSubtestAttempts(result));
+                        this.attempts = coalesceSubtestAttempts([...this.attemptsRaw]);
 
                     const uniques = {};
                     const allSame = {};

--- a/intermittent_tracker/tests.py
+++ b/intermittent_tracker/tests.py
@@ -1,5 +1,6 @@
-from .db import IssuesDB, DashboardDB
+from .db import IssuesDB, DashboardDB, now
 from . import fs, handlers
+import time
 import json
 
 def debug(value):
@@ -67,21 +68,76 @@ assert query(db, 'bar.html') == None
 
 
 dashboard = DashboardDB(":memory:")
+
+# insert output where hashes are unknown, due to being migrated from schema v1
+dashboard.con.execute('INSERT INTO "output" VALUES (NULL,?,?,NULL,NULL)', ('m', 's'))
+
+# insert eight attempts across two submissions with:
+# • weird result timestamps, and two results that are completely identical
+# • three results for the same test where the last result is expected
+# • one expected result for a test with no other results
+# • four results having both of (message,stack) = NULL
+# • two unexpected results having one of (message,stack) = NULL
+# • two unexpected results for the same test where subtest = NULL
+#   (NULL is tricky, because it bypasses naïve UNIQUE constraints)
+# • both submissions completely identical and having no NULL fields
+#   (submissions should never be deduped or treated as UNIQUE)
 dashboard.insert_attempts([
-    {'path':'a','subtest':'b','expected':'FAIL','actual':'PASS','time':1},
-    {'path':'a','subtest':'c','expected':'PASS','actual':'PASS','time':2},
-])
-tests = dashboard.con.execute('SELECT * FROM "test"').fetchall()
-assert debug([tuple(x) for x in tests]) == [(1,'a','=b','b',1,1), (2,'a','=c','c',0,None)]
-outputs = dashboard.con.execute('SELECT * FROM "output"').fetchall()
-assert debug([tuple(x) for x in outputs]) == [(1,None,None,0,0)]
+    {'path':'b','subtest':None,'expected':'FAIL','actual':'PASS','time':2},
+    {'path':'a','subtest':'c','expected':'PASS','actual':'FAIL','time':1},
+    {'path':'a','subtest':'c','expected':'PASS','actual':'FAIL','time':1},
+    {'path':'a','subtest':'c','expected':'PASS','actual':'PASS','time':3},
+    {'path':'a','subtest':'d','expected':'PASS','actual':'FAIL','time':2,'message':'m','stack':None},
+    {'path':'b','subtest':None,'expected':'FAIL','actual':'PASS','time':1,'message':None,'stack':'s'},
+    {'path':'a','subtest':'e','expected':'OK','actual':'ERROR','time':0,'message':'m','stack':'s'},
+], branch='x', build_url='y', pull_url='z', time_for_testing=13)
+dashboard.insert_attempts([
+    {'path':'a','subtest':'f','expected':'PASS','actual':'PASS','time':3},
+], branch='x', build_url='y', pull_url='z', time_for_testing=13)
+
+# there should be five unique tests
+tests = dashboard.con.execute('SELECT * FROM "test"')
+assert debug(tuple(tests.fetchone())) == (1,'b','',None,2,2)  # last_unexpected = 2 !
+assert debug(tuple(tests.fetchone())) == (2,'a','=c','c',2,1)  # (2,1) !
+assert debug(tuple(tests.fetchone())) == (3,'a','=d','d',1,2)
+assert debug(tuple(tests.fetchone())) == (4,'a','=e','e',1,0)
+assert debug(tuple(tests.fetchone())) == (5,'a','=f','f',0,None)  # (0,None) !
+assert tests.fetchone() is None
+
+# there should be four unique outputs
+outputs = dashboard.con.execute('SELECT * FROM "output"')
+assert debug(tuple(outputs.fetchone())) == (1,'m','s',3775001192,453955339)  # reused and hashed!
+assert debug(tuple(outputs.fetchone())) == (2,None,None,0,0)
+assert debug(tuple(outputs.fetchone())) == (3,'m',None,3775001192,0)
+assert debug(tuple(outputs.fetchone())) == (4,None,'s',0,453955339)
+assert outputs.fetchone() is None
+
+# there should be two(!) submissions
+submissions = dashboard.con.execute('SELECT * FROM "submission"')
+assert debug(tuple(submissions.fetchone())) == (1,13,'x','y','z')
+assert debug(tuple(submissions.fetchone())) == (2,13,'x','y','z')
+assert submissions.fetchone() is None
+
+# there should be eight attempts
 attempts = dashboard.con.execute('SELECT * FROM "attempt"')
-assert debug(tuple(attempts.fetchone())) == (1,1,'FAIL','PASS',1,1,1)
-assert debug(tuple(attempts.fetchone())) == (2,2,'PASS','PASS',2,1,1)
+assert debug(tuple(attempts.fetchone())) == (1,1,'FAIL','PASS',2,2,1)
+assert debug(tuple(attempts.fetchone())) == (2,2,'PASS','FAIL',1,2,1)
+assert debug(tuple(attempts.fetchone())) == (3,2,'PASS','FAIL',1,2,1)
+assert debug(tuple(attempts.fetchone())) == (4,2,'PASS','PASS',3,2,1)
+assert debug(tuple(attempts.fetchone())) == (5,3,'PASS','FAIL',2,3,1)
+assert debug(tuple(attempts.fetchone())) == (6,1,'FAIL','PASS',1,4,1)
+assert debug(tuple(attempts.fetchone())) == (7,4,'OK','ERROR',0,1,1)
+assert debug(tuple(attempts.fetchone())) == (8,5,'PASS','PASS',3,2,2)
+assert attempts.fetchone() is None
 
-dashboard.insert_attempts([{'path':'a','subtest':'c','expected':'PASS','actual':'FAIL','time':3}])
-tests = dashboard.con.execute('SELECT * FROM "test"').fetchall()
-assert debug([tuple(x) for x in tests]) == [(1,'a','=b','b',1,1), (2,'a','=c','c',1,3)]
-
+# there should be five unexpected attempts where attempt_id > 1,
+# each with (path,subtest,message,stack,branch,build_url,pull_url) mixed in
+attempts = dashboard.select_attempts(since=1)
+assert debug(attempts.pop(0)) == {'path':'a','subtest':'c','attempt_id':2,'test':2,'expected':'PASS','actual':'FAIL','time':1,'output':2,'submission':1,'message':None,'stack':None,'branch':'x','build_url':'y','pull_url':'z'}
+assert debug(attempts.pop(0)) == {'path':'a','subtest':'c','attempt_id':3,'test':2,'expected':'PASS','actual':'FAIL','time':1,'output':2,'submission':1,'message':None,'stack':None,'branch':'x','build_url':'y','pull_url':'z'}
+assert debug(attempts.pop(0)) == {'path':'a','subtest':'d','attempt_id':5,'test':3,'expected':'PASS','actual':'FAIL','time':2,'output':3,'submission':1,'message':'m','stack':None,'branch':'x','build_url':'y','pull_url':'z'}
+assert debug(attempts.pop(0)) == {'path':'b','subtest':None,'attempt_id':6,'test':1,'expected':'FAIL','actual':'PASS','time':1,'output':4,'submission':1,'message':None,'stack':'s','branch':'x','build_url':'y','pull_url':'z'}
+assert debug(attempts.pop(0)) == {'path':'a','subtest':'e','attempt_id':7,'test':4,'expected':'OK','actual':'ERROR','time':0,'output':1,'submission':1,'message':'m','stack':'s','branch':'x','build_url':'y','pull_url':'z'}
+assert attempts == []
 
 print('All tests passed.')


### PR DESCRIPTION
#6 introduced

* a bug where the client no longer receives the message and stack for any attempts
* a bug where test.last_unexpected was wrong if attempts were submitted out of time order
* a bug where the schema v2 migration reordered rows from their old rowid order
* a bug where subtest attempts were coalesced incorrectly

This patch fixes those bugs, and makes the dashboard test suite a lot more thorough.

Since there’s no production data yet, this only really affects the client, and it’s not at all urgent.