### PR TITLE
dashboard: fix bugs found while integrating with servo

### DIFF
--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -13,7 +13,7 @@ def tests(request):
     else:
         query = 'SELECT * FROM "test" WHERE "last_unexpected" IS NOT NULL ORDER BY "last_unexpected" DESC'
     for test in db.con.execute(query).fetchall():
-        result.append(dict(test) | issues_mixin(test['path']))
+        result.append({**test, **issues_mixin(test['path'])})
     return json.dumps(result)
 
 def get_attempts(request):
@@ -33,14 +33,13 @@ def post_attempts(request):
     return query(request)
 
 def query(request):
-    issues_db = IssuesDB.readonly()
     result = {'known': [], 'unknown': []}
     attempts = request.json['attempts']
     for attempt in attempts:
         test = {'path': attempt['path'], 'subtest': attempt.get('subtest')}
-        issues = issues_db.query(attempt['path'])
+        issues = issues_mixin(attempt['path'])
         if issues:
-            result['known'].append(test | {'issues': issues})
+            result['known'].append({**test, **issues})
         else:
             result['unknown'].append(test)
     return json.dumps(result)

--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -3,7 +3,8 @@ import json
 
 def issues_mixin(path):
     issues = IssuesDB.readonly()
-    return {'issues': issues.query(path)}
+    result = issues.query(path)
+    return {'issues': result} if result else {}
 
 def tests(request):
     db = DashboardDB()

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -1,4 +1,5 @@
 from . import fs
+from .log import logger
 import json
 import sqlite3
 import time
@@ -112,7 +113,7 @@ class DashboardDB:
         start = time.monotonic_ns()
         for attempt in self.con.execute(f'SELECT "path", "subtest", "attempt".*, "message", "stack", "branch", "build_url", "pull_url" FROM "attempt", "test", "output", "submission" WHERE "test" = "test_id" AND "output" = "output_id" AND "submission" = "submission_id" AND "actual" != "expected" {where} ORDER BY "attempt_id"', params).fetchall():
             result.append(dict(attempt))
-        print(f'debug: DashboardDB.select_attempts took {time.monotonic_ns() - start} ns', file=stderr)
+        logger().debug(f'DashboardDB.select_attempts took {time.monotonic_ns() - start} ns')
         return result
 
     def insert_attempt(self, *, submission, path, subtest=None, expected, actual, time,
@@ -149,7 +150,7 @@ class DashboardDB:
         for attempt in attempts:
             self.insert_attempt(submission=submission, **attempt)
         self.con.execute('RELEASE "insert_attempts"')
-        print(f'debug: DashboardDB.insert_attempts took {time.monotonic_ns() - start} ns', file=stderr)
+        logger().debug(f'DashboardDB.insert_attempts took {time.monotonic_ns() - start} ns')
 
 
 def now():

--- a/intermittent_tracker/db.py
+++ b/intermittent_tracker/db.py
@@ -2,6 +2,7 @@ from . import fs
 import json
 import sqlite3
 import time
+from sys import stderr
 from zlib import crc32
 from itertools import count
 
@@ -111,7 +112,7 @@ class DashboardDB:
         start = time.monotonic_ns()
         for attempt in self.con.execute(f'SELECT "path", "subtest", "attempt".*, "message", "stack", "branch", "build_url", "pull_url" FROM "attempt", "test", "output", "submission" WHERE "test" = "test_id" AND "output" = "output_id" AND "submission" = "submission_id" AND "actual" != "expected" {where} ORDER BY "attempt_id"', params).fetchall():
             result.append(dict(attempt))
-        print(f'debug: DashboardDB.select_attempts took {time.monotonic_ns() - start} ns')
+        print(f'debug: DashboardDB.select_attempts took {time.monotonic_ns() - start} ns', file=stderr)
         return result
 
     def insert_attempt(self, *, submission, path, subtest=None, expected, actual, time,
@@ -148,7 +149,7 @@ class DashboardDB:
         for attempt in attempts:
             self.insert_attempt(submission=submission, **attempt)
         self.con.execute('RELEASE "insert_attempts"')
-        print(f'debug: DashboardDB.insert_attempts took {time.monotonic_ns() - start} ns')
+        print(f'debug: DashboardDB.insert_attempts took {time.monotonic_ns() - start} ns', file=stderr)
 
 
 def now():

--- a/intermittent_tracker/log.py
+++ b/intermittent_tracker/log.py
@@ -1,0 +1,25 @@
+import logging
+import sys
+
+
+APP_NAME = 'intermittent_tracker'
+
+
+def logger():
+    """Get the main Flask logger, equivalent to app.logger."""
+    return logging.getLogger(APP_NAME)
+
+
+class WerkzeugFilter(logging.Filter):
+    """Adjust the levels of request logs to help filter them."""
+
+    def filter(self, record):
+        if record.msg.endswith('] "%s" %s %s') and record.levelno == 20:
+            status_code = record.args[1]
+            if status_code.startswith('2'):
+                record.levelname = 'DEBUG'
+                record.levelno = logging.getLevelName(record.levelname)
+            if status_code.startswith('4') or status_code.startswith('5'):
+                record.levelname = 'WARNING'
+                record.levelno = logging.getLevelName(record.levelname)
+        return logging.getLogger(self.name).isEnabledFor(record.levelno)


### PR DESCRIPTION
* dashboard.py uses dict|dict, which is [only available in Python 3.9+](https://docs.python.org/3/whatsnew/3.9.html)
* debug and http 2xx logging was spamming syslog in production
* /dashboard/{attempts,query} always returned attempts in .known and never .unknown