### PR TITLE
Most-flaky: added a GitHub issue link to corresponding test in most-flaky view

### DIFF
--- a/intermittent_tracker/dashboard.py
+++ b/intermittent_tracker/dashboard.py
@@ -48,14 +48,14 @@ def query(request):
 def most_flaky(limit=100):
     db = DashboardDB()
     result = []
-    
     query = f'SELECT path, SUM(unexpected_count) AS total_unexpected_count FROM "test" GROUP BY path ORDER BY total_unexpected_count DESC LIMIT {limit}'
     query_result = db.con.execute(query).fetchall()
-
     for row in query_result:
         test = {
             'path': row['path'],
             'total_unexpected_count': row['total_unexpected_count']
         }
+        issues = issues_mixin(test['path'])
+        test['issues'] = issues
         result.append(test)
     return result

--- a/intermittent_tracker/static/style.css
+++ b/intermittent_tracker/static/style.css
@@ -22,6 +22,9 @@ pre, code {
 table.big tr:nth-child(2n) {
     background: #e0e0e0;
 }
+table.big td:last-child {
+    width: auto;
+}
 td, th {
     vertical-align: top;
 }

--- a/intermittent_tracker/templates/most_flaky.html
+++ b/intermittent_tracker/templates/most_flaky.html
@@ -24,22 +24,23 @@
                     <th>#</th>
                     <th>Test Path</th>
                     <th>Number of Unexpected Results</th>
-                    <th>GitHub Link</th>
                 </tr>
             </thead>
             <tbody>
                 {% for test in tests %}
                 <tr>
                     <td>{{ loop.index }}</td>
-                    <td>{{ test.path }}</td>
-                    <td>{{ test.total_unexpected_count }}</td>
                     <td>
+                        {{ test.path }}
                         {% if test.issues %}
-                            <a href="https://github.com/servo/servo/issues/{{ test.issues.issues[0].number }}" rel="noopener" target="_blank">issue #{{test.issues.issues[0].number}}</a>
-                        {% else %}
-                            No issues found
+                        {% for issue in test.issues.issues %}
+                        <a href="https://github.com/servo/servo/issues/{{ issue.number }}" rel="noopener" target="_blank">
+                            (#{{ issue.number }})
+                        </a>
+                        {% endfor %}
                         {% endif %}
                     </td>
+                    <td>{{ test.total_unexpected_count }}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/intermittent_tracker/templates/most_flaky.html
+++ b/intermittent_tracker/templates/most_flaky.html
@@ -9,38 +9,42 @@
 </head>
 
 <body>
-    <form action="/most-flaky" method="get">
-        <label for="limit">Limit:</label>
-        <input type="number" id="limit" name="limit" min="0">
-        <button type="submit">Apply</button>
-    </form>
+    <div class="main-content">
+        <h2>Flakiest Tests</h2>
+        
+        <form action="/most-flaky" method="get">
+            <label for="limit">Limit:</label>
+            <input type="number" id="limit" name="limit" min="0">
+            <button type="submit">Apply</button>
+        </form>
 
-    <table class="big" border="1">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Test Path</th>
-                <th>Number of Unexpected Results</th>
-                <th>GitHub Issue</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for test in tests %}
-            <tr>
-                <td>{{ loop.index }}</td>
-                <td>{{ test.path }}</td>
-                <td>{{ test.total_unexpected_count }}</td>
-                <td>
-                    {% if test.issues %}
-                        <a href="https://github.com/servo/servo/issues/{{ test.issues.issues[0].number }}" rel=”noopener" target="_blank">{{ test.issues.issues[0].title }}</a>
-                    {% else %}
-                        No issues found
-                    {% endif %}
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+        <table class="big" border="1">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Test Path</th>
+                    <th>Number of Unexpected Results</th>
+                    <th>GitHub Link</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for test in tests %}
+                <tr>
+                    <td>{{ loop.index }}</td>
+                    <td>{{ test.path }}</td>
+                    <td>{{ test.total_unexpected_count }}</td>
+                    <td>
+                        {% if test.issues %}
+                            <a href="https://github.com/servo/servo/issues/{{ test.issues.issues[0].number }}" rel="noopener" target="_blank">issue #{{test.issues.issues[0].number}}</a>
+                        {% else %}
+                            No issues found
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 </body>
 
 </html>

--- a/intermittent_tracker/templates/most_flaky.html
+++ b/intermittent_tracker/templates/most_flaky.html
@@ -32,13 +32,13 @@
                     <td>{{ loop.index }}</td>
                     <td>
                         {{ test.path }}
-                        {% if test.issues %}
-                        {% for issue in test.issues.issues %}
-                        <a href="https://github.com/servo/servo/issues/{{ issue.number }}" rel="noopener" target="_blank">
-                            (#{{ issue.number }})
-                        </a>
-                        {% endfor %}
-                        {% endif %}
+                        {%- if test.issues -%}
+                        ({%- for issue in test.issues.issues -%}
+                        <a href="https://github.com/servo/servo/issues/{{ issue.number }}" rel="noopener" target="_blank">{{ '#' ~ issue.number }}</a>
+                        {%- if not loop.last -%},
+                        {% endif -%}
+                        {%- endfor -%})
+                        {%- endif -%}
                     </td>
                     <td>{{ test.total_unexpected_count }}</td>
                 </tr>

--- a/intermittent_tracker/templates/most_flaky.html
+++ b/intermittent_tracker/templates/most_flaky.html
@@ -21,6 +21,7 @@
                 <th>#</th>
                 <th>Test Path</th>
                 <th>Number of Unexpected Results</th>
+                <th>GitHub Issue</th>
             </tr>
         </thead>
         <tbody>
@@ -29,6 +30,13 @@
                 <td>{{ loop.index }}</td>
                 <td>{{ test.path }}</td>
                 <td>{{ test.total_unexpected_count }}</td>
+                <td>
+                    {% if test.issues %}
+                        <a href="https://github.com/servo/servo/issues/{{ test.issues.issues[0].number }}" rel=”noopener" target="_blank">{{ test.issues.issues[0].title }}</a>
+                    {% else %}
+                        No issues found
+                    {% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
**Context:**
 
The most-flaky view lists each test, but it would be useful to have a link to the corresponding GitHub issue for each of those tests.


Changes made:
- Added the corresponding issues at the end of each flaky test path to address the need for links to the corresponding GitHub issues.
- Updated the HTML template to conditionally display GitHub links based on the presence of issues.


<br class="Apple-interchange-newline"> 


- [x] This PR fixes #17
- [x] `python3 -m intermittent_tracker.tests` doesn't report any error

