### PR TITLE
fix: Fixed url related bugs in most-flaky view

### DIFF
--- a/intermittent_tracker/templates/most_flaky.html
+++ b/intermittent_tracker/templates/most_flaky.html
@@ -5,14 +5,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flakiest Tests</title>
-    <link rel="stylesheet" href="../static/style.css">
+    <link rel="stylesheet" href="static/style.css">
 </head>
 
 <body>
     <div class="main-content">
         <h2>Flakiest Tests</h2>
-        
-        <form action="/most-flaky" method="get">
+
+        <form action="{{ url_for('most_flaky') }}" method="get">
             <label for="limit">Limit:</label>
             <input type="number" id="limit" name="limit" min="0">
             <button type="submit">Apply</button>
@@ -32,7 +32,7 @@
                     <td>{{ loop.index }}</td>
                     <td>
                         {{ test.path }}
-                        {%- if test.issues -%}
+                        {% if test.issues -%}
                         ({%- for issue in test.issues.issues -%}
                         <a href="https://github.com/servo/servo/issues/{{ issue.number }}" rel="noopener" target="_blank">{{ '#' ~ issue.number }}</a>
                         {%- if not loop.last -%},


### PR DESCRIPTION
In deployment server most-flaky view introduced following bugs (please refer to attached screenshots):

- Incorrect Form Action URL:

From: `<form action="/most-flaky" method="get">`
Changed to: `<form action="{{ url_for('most_flaky') }}" method="get">`
Explanation: By using the url_for function in Flask, URL now dynamically generated for the most_flaky endpoint. This ensures that the form submission is directed to the correct route regardless of any changes in the application's URL structure.

- Faulty Style Path:

From: `<link rel="stylesheet" href="../static/style.css">`
Changed to: `<link rel="stylesheet" href="static/style.css">`
Explanation: Corrected the path to style.css file, the stylesheet is now properly loaded, fixing the issue where styles were not being applied on the deployment server.

- Screenshots:
<img width="1243" alt="Screenshot 2024-03-29 at 22 51 49" src="https://github.com/servo/intermittent-tracker/assets/31756707/5f90818a-a307-439d-821d-f12f48e837a1">
<img width="1059" alt="Screenshot 2024-03-29 at 22 52 00" src="https://github.com/servo/intermittent-tracker/assets/31756707/82c8f31f-3e5b-458a-ac94-1bcb1e81e501">

---
- [x] `python3 -m intermittent_tracker.tests` All tests have passed
